### PR TITLE
Remove MOVE from drop intent check

### DIFF
--- a/src/mods/creep/creep.ts
+++ b/src/mods/creep/creep.ts
@@ -467,7 +467,7 @@ function checkFatigue(creep: Creep) {
 
 export function checkDrop(creep: Creep, resourceType: ResourceType, amount: number) {
 	return chainIntentChecks(
-		() => checkCommon(creep, C.MOVE),
+		() => checkCommon(creep),
 		() => checkHasResource(creep, resourceType, amount));
 }
 


### PR DESCRIPTION
`MOVE` should not be required to successfully `drop`.